### PR TITLE
Also check for top bit set in raw commands.

### DIFF
--- a/common/tuffLib/tuffLib.c
+++ b/common/tuffLib/tuffLib.c
@@ -413,7 +413,7 @@ int tuff_getfd(tuff_dev_t * dev)
 int tuff_rawCommand(tuff_dev_t * d, unsigned int irfcm,  unsigned int tuffStack, unsigned int cmd)
 {
 
-  if ( (cmd & 0xE0) == 0x40) 
+  if ( ((cmd & 0xE0) == 0x40) || (cmd & 0x8000)) 
   {
     fprintf(stderr, "Prevented dangerous raw TUFF command  (%x) from being sent, cmd\n",cmd); 
     syslog(LOG_ERR, "Prevented dangerous raw TUFF command  (%x) from being sent, cmd\n",cmd); 


### PR DESCRIPTION
Raw commands with a top bit set are 'global' commands intended only for use by the TUFF master - namely, reset/lock (0xFFFF) and synchronize/unlock (0xD00D).  Accidentally sending 'reset' would put the TUFFs back into 'reset/locked' mode. This isn't horrible - sending a tuffReset command would bring them back - but it could be confusing since the TUFFs, in locked mode, just act as if they don't hear anything.
